### PR TITLE
Add WithinMPOnly parameter to ModelField 

### DIFF
--- a/PyGeopack/__data/libgeopack/ModelField.c
+++ b/PyGeopack/__data/libgeopack/ModelField.c
@@ -1,7 +1,7 @@
 #include "ModelField.h"
 
 
-void ModelField(float *Xin, float *Yin, float *Zin, int n, int Date, float ut, const char *Model, int CoordIn, int CoordOut, float *Bx, float *By, float *Bz) {
+void ModelField(float *Xin, float *Yin, float *Zin, int n, int Date, float ut, const char *Model, int CoordIn, int CoordOut, int WithinMPOnly, float *Bx, float *By, float *Bz) {
 
 	/*Check that TSData has been loaded*/
 	if (TSData.n == 0) {

--- a/PyGeopack/__data/libgeopack/ModelField.h
+++ b/PyGeopack/__data/libgeopack/ModelField.h
@@ -8,5 +8,5 @@
 
 //CtypeStart
 //PyFunc iiiiiiiiiooo
-void ModelField(float *Xin, float *Yin, float *Zin, int n, int Date, float ut, const char *Model, int CoordIn, int CoordOut, float *Bx, float *By, float *Bz);
+void ModelField(float *Xin, float *Yin, float *Zin, int n, int Date, float ut, const char *Model, int CoordIn, int CoordOut, int WithinMPOnly, float *Bx, float *By, float *Bz);
 //CtypeStop

--- a/PyGeopack/__data/libgeopack/data/for/ModelField.c
+++ b/PyGeopack/__data/libgeopack/data/for/ModelField.c
@@ -1,7 +1,7 @@
 #include "ModelField.h"
 
 
-void ModelField(float *Xin, float *Yin, float *Zin, int n, int Date, float ut, const char *Model, int CoordIn, int CoordOut, float *Bx, float *By, float *Bz) {
+void ModelField(float *Xin, float *Yin, float *Zin, int n, int Date, float ut, const char *Model, int CoordIn, int CoordOut, int WithinMPOnly, float *Bx, float *By, float *Bz) {
 
 	/*Check that TSData has been loaded*/
 	if (TSData.n == 0) {

--- a/PyGeopack/__data/libgeopackcpp/modelfield.h
+++ b/PyGeopack/__data/libgeopackcpp/modelfield.h
@@ -24,6 +24,7 @@ typedef struct ModelCFG{
 	double *Vz;
 	const char *CoordIn;
 	const char *CoordOut;
+	bool WithinMPOnly;
 } ModelCFG;
 #endif
 
@@ -38,14 +39,14 @@ extern "C" {
 						int *Date, float *ut, bool SameTime,
 						const char *Model, int *iopt, double **parmod,
 						double *Vx, double *Vy, double *Vz,
-						const char *CoordIn, const char *CoordOut, 
+						const char *CoordIn, const char *CoordOut, bool WithinMPOnly, 
 						double *Bx, double *By, double *Bz);
 	
 	void ModelFieldWrap(int n, double *Xin, double *Yin, double *Zin,  
 						int *Date, float *ut, bool SameTime,
 						const char *Model, int *iopt, double **parmod,
 						double *Vx, double *Vy, double *Vz,
-						const char *CoordIn, const char *CoordOut, 
+						const char *CoordIn, const char *CoordOut, bool WithinMPOnly,
 						double *Bx, double *By, double *Bz);
 	
 	
@@ -54,7 +55,7 @@ extern "C" {
 ModelCFG GetModelCFG(	int n, int *Date, float *ut, bool SameTime,
 						const char *Model, int *iopt, double **parmod,
 						double *Vx, double *Vy, double *Vz,
-						const char *CoordIn, const char *CoordOut); 
+						const char *CoordIn, const char *CoordOut, bool WithinMPOnly); 
 
 void ModelFieldNew(	int n, double *Xin, double *Yin, double *Zin, 
 					ModelCFG cfg,double *Bx, double *By, double *Bz);

--- a/PyGeopack/__data/libgeopackcpp/tracing/trace.cc
+++ b/PyGeopack/__data/libgeopackcpp/tracing/trace.cc
@@ -755,7 +755,7 @@ void Trace::_TraceGSM() {
 			/*get B vectors along trace*/
 			ModelField(nstep_[i],xgsm_[i],ygsm_[i],zgsm_[i],
 						&Date_[i],&ut_[i],true,Model_,&iopt_[i],&parmod_[i],
-						&Vx_[i],&Vy_[i],&Vz_[i],"GSM","GSM",
+						&Vx_[i],&Vy_[i],&Vz_[i],"GSM","GSM", false,
 						bxgsm_[i],bygsm_[i],bzgsm_[i]);
 
 		} else {

--- a/PyGeopack/__data/libgeopackcpp/tracing/tracefield.cc
+++ b/PyGeopack/__data/libgeopackcpp/tracing/tracefield.cc
@@ -129,7 +129,7 @@ void TraceFieldOld(double *Xin, double *Yin, double *Zin, int n,
 			/*get B vectors along trace*/
 			ModelField(nstep[i],Xout[i],Yout[i],Zout[i],
 						&Date[i],&ut[i],true,Model,&iopt[i],&parmod[i],
-						&Vx[i],&Vy[i],&Vz[i],"GSM","GSM",
+						&Vx[i],&Vy[i],&Vz[i],"GSM","GSM", false,
 						Bx[i],By[i],Bz[i]);
 
 			/* Get the distance along the field line*/

--- a/PyGeopack/__data/libgeopackdp/ModelField.c
+++ b/PyGeopack/__data/libgeopackdp/ModelField.c
@@ -3,8 +3,8 @@
 
 void ModelField(	double *Xin, double *Yin, double *Zin, int n, 
 					int *Date, float *ut, int SameTime, 
-					const char *Model,	int CoordIn, int CoordOut, 
-					double *Bx, double *By, double *Bz) {
+			const char *Model,	int CoordIn, int CoordOut, int WithinMPOnly,
+			double *Bx, double *By, double *Bz) {
 
 	/*Check that TSData has been loaded*/
 	if (TSData.n == 0) {
@@ -118,20 +118,21 @@ void ModelField(	double *Xin, double *Yin, double *Zin, int n,
 
 		/*check if we are within the magnetopause or not */
 		inMP = WithinMP(X[i],Y[i],Z[i],parmod[3],parmod[0]);
-		if (inMP) {
+		
+		if (WithinMPOnly && !inMP) {
+			/* fill with NAN */
+			Bxgsm[i] = NAN;
+			Bygsm[i] = NAN;
+			Bzgsm[i] = NAN;		  
+		} else {
 			/*call relevant model code*/
 			igrf_gsw_08_(&X[i],&Y[i],&Z[i],&intx,&inty,&intz);
 			ModelFunc(&iopt,parmod,&tilt,&X[i],&Y[i],&Z[i],&extx,&exty,&extz);
 			Bxgsm[i] = intx + extx;
 			Bygsm[i] = inty + exty;
 			Bzgsm[i] = intz + extz;
-		} else { 
-			/* fill with NAN */
-			Bxgsm[i] = NAN;
-			Bygsm[i] = NAN;
-			Bzgsm[i] = NAN;
 		}
-
+		
 		/*now to convert the vectors to the desired output coordinates*/
 		switch (CoordOut) {
 			case 1:

--- a/PyGeopack/__data/libgeopackdp/ModelField.h
+++ b/PyGeopack/__data/libgeopackdp/ModelField.h
@@ -14,6 +14,6 @@
  * ********************************************************************/
 void ModelField(	double *Xin, double *Yin, double *Zin, int n, 
 					int *Date, float *ut, int SameTime, 
-					const char *Model,	int CoordIn, int CoordOut, 
-					double *Bx, double *By, double *Bz);
+			const char *Model,	int CoordIn, int CoordOut, int WithinMPOnly,
+			double *Bx, double *By, double *Bz);
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ where the output field components `Bx`, `By` and `Bz` are in units of nT.
 The `ModelField` function accepts the following arguments and keywords:
 
 | Name           | Keyword/Argument | Description                                                                                                           |
-| -------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+|----------------|------------------|-----------------------------------------------------------------------------------------------------------------------|
 | `x`            | argument         | Scalar or array of x-coordinates                                                                                      |
 | `y`            | argument         | Scalar or array of y-coordinates                                                                                      |
 | `z`            | argument         | Scalar or array of z-coordinates                                                                                      |
@@ -111,6 +111,7 @@ The `ModelField` function accepts the following arguments and keywords:
 | `Model`        | keyword          | String denoting the model to use `'T89'\|'T96'\|'T01'\|'TS05'`                                                        |
 | `CoordIn`      | keyword          | Input coordinate system string: `'GSE'\|'GSM'\|'SM'`                                                                  |
 | `CoordOut`     | keyword          | Output coordinate system string: `'GSE'\|'GSM'\|'SM'`                                                                 |
+| `WithinMPOnly  | keyword          | If `True` then return NaN's outside the magnetopause.                                                                 |
 | `ReturnParams` | keyword          | If `True` then a dictionary containing the model parameters will be returned as a fourth output parameter.            |
 | `**kwargs`     | keywords         | Keyword arguments can be used to define some or all of the model parameters used. See model parameters section.       |
 


### PR DESCRIPTION
This merge request is in response to discussion in issue #12. It removes the default behaviour of returning NaN's outside the MP, with the old behaviour still attainable by setting a new keyword arg `WithinMPOnly=True`.

I tried to respect convention as much as possible in this merge request, with respect to argument ordering and general style. Let me know if I fell short somewhere.

Best,
Daniel